### PR TITLE
マージボタンが無効にならない不具合を修正した

### DIFF
--- a/coffee/lgtm.coffee
+++ b/coffee/lgtm.coffee
@@ -101,13 +101,13 @@ class LGTM
       $(page).append(container)
 
     if @disableMerge and count < @disableMergeThreshold
-      $(".merge-branch-action").prop("disabled", true)
-      $(".merge-branch-action").text("Not reviewed")
+      $(".js-merge-branch-action").prop("disabled", true)
+      $(".js-merge-branch-action").text("Not reviewed")
 
     title = $(".js-issue-title").html()
     if @isWIP(title)
-      $(".merge-branch-action").prop("disabled", true)
-      $(".merge-branch-action").text("WIP")
+      $(".js-merge-branch-action").prop("disabled", true)
+      $(".js-merge-branch-action").text("WIP")
 
 
   refresh: () ->


### PR DESCRIPTION
### 問題

タイトルに wip が付いている場合、
+1 が一定数集まっている場合等でもマージボタンが無効にならず
常に有効になっていた。
### 対応

マージボタンのclass名が現状にあっていなかったので、現状のclass名にした。
